### PR TITLE
Add high level profiling trace for dataloading and optimizer

### DIFF
--- a/test/test_profiler.py
+++ b/test/test_profiler.py
@@ -153,17 +153,16 @@ class TestProfiler(TestCase):
 
         expected_event_count = {
             # "+1" because the final iteration will enter __next__ but skip the loop body.
-            "_BaseDataLoaderIter.__next__":N + 1,
-            "Optimizer.step":N,
-            "Optimizer.zero_grad":N
+            "enumerate(DataLoader)#_SingleProcessDataLoaderIter.__next__":N + 1,
+            "Optimizer.step#SGD.step":N,
+            "Optimizer.zero_grad#SGD.zero_grad":N
             }
         actual_event_count = {}
         for e in prof.function_events:
             if "#" in e.name:
-                parts = e.name.split("#")
-                key = parts[1]
+                key = e.name
                 if key in expected_event_count.keys():
-                    actual_event_count[key] = actual_event_count.get(key, 0) + 1
+                    actual_event_count[key] = actual_event_count.setdefault(key, 0) + 1
         for key, count in expected_event_count.items():
             self.assertTrue((key in actual_event_count.keys()) and (count == actual_event_count[key]))
 

--- a/test/test_profiler.py
+++ b/test/test_profiler.py
@@ -153,9 +153,9 @@ class TestProfiler(TestCase):
 
         expected_event_count = {
             # "+1" because the final iteration will enter __next__ but skip the loop body.
-            "enumerate(DataLoader)#_SingleProcessDataLoaderIter.__next__":N + 1,
-            "Optimizer.step#SGD.step":N,
-            "Optimizer.zero_grad#SGD.zero_grad":N
+            "enumerate(DataLoader)#_SingleProcessDataLoaderIter.__next__": N + 1,
+            "Optimizer.step#SGD.step": N,
+            "Optimizer.zero_grad#SGD.zero_grad": N
             }
         actual_event_count = {}
         for e in prof.function_events:

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -5,6 +5,7 @@ import torch
 from copy import deepcopy
 from itertools import chain
 import warnings
+import functools
 
 
 class _RequiredParameter(object):
@@ -33,6 +34,7 @@ class Optimizer(object):
     def __init__(self, params, defaults):
         torch._C._log_api_usage_once("python.optimizer")
         self.defaults = defaults
+        self.step = self._step_wrapper()
 
         if isinstance(params, torch.Tensor):
             raise TypeError("params argument given to the optimizer should be "
@@ -71,6 +73,15 @@ class Optimizer(object):
                     format_string += '    {0}: {1}\n'.format(key, group[key])
         format_string += ')'
         return format_string
+
+    def _step_wrapper(self):
+        func = self.step
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            profile_label = str.format("{}#{}", func.__qualname__, "Optimizer.step")
+            with torch.autograd.profiler.record_function(profile_label):
+                return func(*args, **kwargs)
+        return wrapper
 
     def state_dict(self):
         r"""Returns the state of the optimizer as a :class:`dict`.
@@ -179,17 +190,19 @@ class Optimizer(object):
                 (in one case it does the step with a gradient of 0 and in the other it skips
                 the step altogether).
         """
-        for group in self.param_groups:
-            for p in group['params']:
-                if p.grad is not None:
-                    if set_to_none:
-                        p.grad = None
-                    else:
-                        if p.grad.grad_fn is not None:
-                            p.grad.detach_()
+        profile_label = str.format("{}.{}#{}", self.__class__.__name__, "zero_grad", "Optimizer.zero_grad")
+        with torch.autograd.profiler.record_function(profile_label):
+            for group in self.param_groups:
+                for p in group['params']:
+                    if p.grad is not None:
+                        if set_to_none:
+                            p.grad = None
                         else:
-                            p.grad.requires_grad_(False)
-                        p.grad.zero_()
+                            if p.grad.grad_fn is not None:
+                                p.grad.detach_()
+                            else:
+                                p.grad.requires_grad_(False)
+                            p.grad.zero_()
 
     def step(self, closure):
         r"""Performs a single optimization step (parameter update).

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -75,6 +75,7 @@ class Optimizer(object):
         return format_string
 
     def _step_wrapper(self):
+        """Wrap self.step under profiler. In order to avoid of instrumenting each sub-class."""
         func = self.step
         @functools.wraps(func)
         def wrapper(*args, **kwargs):

--- a/torch/optim/optimizer.py
+++ b/torch/optim/optimizer.py
@@ -78,7 +78,7 @@ class Optimizer(object):
         """Wrap self.step under profiler. In order to avoid of instrumenting each sub-class."""
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            name = str.format("{}#{}", func.__qualname__, "Optimizer.step")
+            name = str.format("{}#{}", "Optimizer.step", func.__qualname__)
             with torch.autograd.profiler.record_function(name):
                 return func(*args, **kwargs)
         return wrapper
@@ -190,7 +190,7 @@ class Optimizer(object):
                 (in one case it does the step with a gradient of 0 and in the other it skips
                 the step altogether).
         """
-        name = str.format("{}.{}#{}", self.__class__.__name__, "zero_grad", "Optimizer.zero_grad")
+        name = str.format("{}#{}.{}", "Optimizer.zero_grad", self.__class__.__name__, "zero_grad")
         with torch.autograd.profiler.record_function(name):
             for group in self.param_groups:
                 for p in group['params']:

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -514,22 +514,24 @@ class _BaseDataLoaderIter(object):
         raise NotImplementedError
 
     def __next__(self) -> Any:
-        if self._sampler_iter is None:
-            self._reset()
-        data = self._next_data()
-        self._num_yielded += 1
-        if self._dataset_kind == _DatasetKind.Iterable and \
-                self._IterableDataset_len_called is not None and \
-                self._num_yielded > self._IterableDataset_len_called:
-            warn_msg = ("Length of IterableDataset {} was reported to be {} (when accessing len(dataloader)), but {} "
-                        "samples have been fetched. ").format(self._dataset, self._IterableDataset_len_called,
-                                                              self._num_yielded)
-            if self._num_workers > 0:
-                warn_msg += ("For multiprocessing data-loading, this could be caused by not properly configuring the "
-                             "IterableDataset replica at each worker. Please see "
-                             "https://pytorch.org/docs/stable/data.html#torch.utils.data.IterableDataset for examples.")
-            warnings.warn(warn_msg)
-        return data
+        profile_label = "_BaseDataLoaderIter.__next__#_BaseDataLoaderIter.__next__"
+        with torch.autograd.profiler.record_function(profile_label):
+            if self._sampler_iter is None:
+                self._reset()
+            data = self._next_data()
+            self._num_yielded += 1
+            if self._dataset_kind == _DatasetKind.Iterable and \
+                    self._IterableDataset_len_called is not None and \
+                    self._num_yielded > self._IterableDataset_len_called:
+                warn_msg = ("Length of IterableDataset {} was reported to be {} (when accessing len(dataloader)), but {} "
+                            "samples have been fetched. ").format(self._dataset, self._IterableDataset_len_called,
+                                                                self._num_yielded)
+                if self._num_workers > 0:
+                    warn_msg += ("For multiprocessing data-loading, this could be caused by not properly configuring the "
+                                "IterableDataset replica at each worker. Please see "
+                                "https://pytorch.org/docs/stable/data.html#torch.utils.data.IterableDataset for examples.")
+                warnings.warn(warn_msg)
+            return data
 
     next = __next__  # Python 2 compatibility
 

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -514,8 +514,8 @@ class _BaseDataLoaderIter(object):
         raise NotImplementedError
 
     def __next__(self) -> Any:
-        profile_label = "_BaseDataLoaderIter.__next__#_BaseDataLoaderIter.__next__"
-        with torch.autograd.profiler.record_function(profile_label):
+        name = "_BaseDataLoaderIter.__next__#_BaseDataLoaderIter.__next__"
+        with torch.autograd.profiler.record_function(name):
             if self._sampler_iter is None:
                 self._reset()
             data = self._next_data()

--- a/torch/utils/data/dataloader.py
+++ b/torch/utils/data/dataloader.py
@@ -514,7 +514,7 @@ class _BaseDataLoaderIter(object):
         raise NotImplementedError
 
     def __next__(self) -> Any:
-        name = "_BaseDataLoaderIter.__next__#_BaseDataLoaderIter.__next__"
+        name = str.format("{}#{}.{}", "enumerate(DataLoader)", self.__class__.__name__, "__next__")
         with torch.autograd.profiler.record_function(name):
             if self._sampler_iter is None:
                 self._reset()


### PR DESCRIPTION
Fixes #{47441}

To give user more information about python level functions in profiler traces, we propose to add some instrumenting on the following functions:

```
_BaseDataLoaderIter.__next__
Optimizer.step
Optimizer.zero_grad
```
`record_function` already uses `if (!active)` to check whether the profiler is enabled, so we don't explicitly called `torch.autograd._profiler_enabled()` before every instrument.